### PR TITLE
Process TracWiki links and formatting. (#4)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,8 @@ You might want to add a `_Sidebar.rst` file in the root with::
     * `<Administrative>`_
     * `<Development>`_
     * `<Infrastructure>`_
+     * `<Infrastructure-Services>`_
+     * `<Infrastructure-Machines>`_
     * `<Support>`_
 
 For wiki content conversion::

--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,13 @@ Create a virtualenv::
     mv config.py.sample config.py
 
 
-For wiki migration::
+For wiki migration.
+All pages are generated into a flat file structure.
+Spaces are used instead of path separators::
 
     python wiki_migrate.py PATH/TO/Trac.DB PATH/TO/GIT-REPO
 
-You might want to add a `_Sidebar.rst` file in the root wit::
+You might want to add a `_Sidebar.rst` file in the root with::
 
     * `<Administrative>`_
     * `<Development>`_
@@ -28,3 +30,10 @@ You might want to add a `_Sidebar.rst` file in the root wit::
 For wiki content conversion::
 
     python wiki_trac_rst_convert.py PATH/TO/GIT-REPO
+
+
+Things that are not yet auto-converted:
+
+* TracWiki 3rd level heading `=== Some sub-section ===`
+* Sub-pages listing macro `[[TitleIndex(Development/)]]`
+* Local table of content `[[PageOutline]]`

--- a/README.rst
+++ b/README.rst
@@ -41,3 +41,4 @@ Things that are not yet auto-converted:
 * TracWiki 3rd level heading `=== Some sub-section ===`
 * Sub-pages listing macro `[[TitleIndex(Development/)]]`
 * Local table of content `[[PageOutline]]`
+* Manually create _Sidebar.rst and _Footer.rst GitHub wiki meta-pages.

--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,10 @@ You might want to add a `_Sidebar.rst` file in the root with::
     * `<Administrative>`_
     * `<Development>`_
     * `<Infrastructure>`_
-     * `<Infrastructure-Services>`_
-     * `<Infrastructure-Machines>`_
+
+      * `Services <Infrastructure-Services>`_
+      * `Machines <Infrastructure-Machines>`_
+
     * `<Support>`_
 
 For wiki content conversion::

--- a/config.py.sample
+++ b/config.py.sample
@@ -2,3 +2,5 @@
 USER_MAPPING = {
     'adi': ('adiroiban', 'Adi Roiban <adi.roiban@chevah.com>'),
     }
+
+TRAC_TICKET_PREFIX = 'https://trac.chevah.com/ticket/'

--- a/test/test_wiki_trac_rst_convert.py
+++ b/test/test_wiki_trac_rst_convert.py
@@ -3,18 +3,21 @@ import unittest
 from wiki_trac_rst_convert import convert_content
 
 
-class TracToVanillaRst(unittest.TestCase):
+class TracToGitHubRST(unittest.TestCase):
     """
-    Test conversion of content from Trac-flavored reStructuredText to
-    vanilla reStructuredText, that is supported by GitHub
+    Test conversion of content from Trac-flavored reStructuredText and
+    TracWiki markup, into reStructuredText that is supported by GitHub
     """
 
     def assertConvertedContent(self, expected: str, source: str):
         """
         Run the Trac RST `source` through the converter,
         and assert that the output equals `expected`.
+
+        Also expects the content to end with a newline. The newline is
+        added here for convenience and readability of test cases.
         """
-        self.assertEqual(expected, convert_content(source))
+        self.assertEqual(expected + '\n', convert_content(source))
 
     def test_empty(self):
         """
@@ -25,13 +28,13 @@ class TracToVanillaRst(unittest.TestCase):
         saying "No newline at end of file".
         https://stackoverflow.com/a/729795/235463
         """
-        self.assertConvertedContent('\n', '')
+        self.assertConvertedContent('', '')
 
     def test_newline(self):
         """
         A newline will not get appended another newline.
         """
-        self.assertConvertedContent('\n', '\n')
+        self.assertConvertedContent('', '\n')
 
     def test_removes_rst_wrapping(self):
         """
@@ -39,9 +42,9 @@ class TracToVanillaRst(unittest.TestCase):
         {{{ #!rst }}} markers.
         It removes the TracWiki RST armor markup from the output.
         """
-        self.assertConvertedContent('\n', '{{{#!rst}}}')
+        self.assertConvertedContent('', '{{{#!rst}}}')
         self.assertConvertedContent(
-            '\n',
+            '',
             '\n'
             '{{{\n'
             '#!rst'
@@ -53,7 +56,7 @@ class TracToVanillaRst(unittest.TestCase):
         Both RST and non-RST content is preserved, after stripping the markers.
         """
         self.assertConvertedContent(
-            'some RST content and some non-RST content\n',
+            'some RST content and some non-RST content',
             '{{{#!rst some RST content}}} and some non-RST content'
         )
 
@@ -63,7 +66,7 @@ class TracToVanillaRst(unittest.TestCase):
         """
 
         self.assertConvertedContent(
-            '`<Requirements>`_\n',
+            '`<Requirements>`_',
             ':trac:`wiki:Requirements`'
         )
 
@@ -74,7 +77,7 @@ class TracToVanillaRst(unittest.TestCase):
         """
 
         self.assertConvertedContent(
-            '`<General-FreeSoftwareUsage>`_\n',
+            '`<General-FreeSoftwareUsage>`_',
             ':trac:`wiki:General/FreeSoftwareUsage`'
         )
 
@@ -85,7 +88,7 @@ class TracToVanillaRst(unittest.TestCase):
         """
 
         self.assertConvertedContent(
-            '`<Infrastructure-Services-LAN#services>`_\n',
+            '`<Infrastructure-Services-LAN#services>`_',
             '`wiki:Infrastructure/Services/LAN#services`:trac:'
         )
 
@@ -99,7 +102,7 @@ class TracToVanillaRst(unittest.TestCase):
             '* `<Requirements>`_\n'
             '* Some content\n'
             '* `<General-FreeSoftwareUsage>`_'
-            ' List of free software used by Chevah Project.\n',
+            ' List of free software used by Chevah Project.',
 
             '* :trac:`wiki:Requirements`\n'
             '* Some content\n'
@@ -112,7 +115,7 @@ class TracToVanillaRst(unittest.TestCase):
         Process general links from TracWiki format to plain RST links
         """
         self.assertConvertedContent(
-            '`Buildbot <https://chevah.com/buildbot/>`_\n',
+            '`Buildbot <https://chevah.com/buildbot/>`_',
             '[https://chevah.com/buildbot/ Buildbot]'
         )
 
@@ -120,44 +123,162 @@ class TracToVanillaRst(unittest.TestCase):
         """
         Process wiki links from TracWiki format to GitHub-compatible
         RST wiki links.
-        There are various combinations of no-link-text, link-text-same-
-        as-article-name, and link-text-different-from-article-name.
+
+        There are various combinations of:
+        * link text different from article name
+        * link text the same as article name, and
+        * no link text, only article name
         """
         self.assertConvertedContent(
-            '`Project management and administration <Administrative>`_\n',
+            '`Project management and administration <Administrative>`_',
             '[wiki:Administrative Project management and administration]'
         )
         self.assertConvertedContent(
-            '`<Administrative>`_\n',
+            '`<Administrative>`_',
             '[wiki:Administrative Administrative]'
         )
         self.assertConvertedContent(
-            '`<Administrative>`_\n',
+            '`<Administrative>`_',
             '[wiki:"Administrative"]'
         )
         self.assertConvertedContent(
-            '`<Administrative-AllHandMeeting-Past>`_\n',
+            '`<Administrative-AllHandMeeting-Past>`_',
             '[wiki:"Administrative/AllHandMeeting/Past"]'
         )
         self.assertConvertedContent(
-            '`<Infrastructure-Services-FileServer>`_\n',
+            '`<Infrastructure-Services-FileServer>`_',
             '`[wiki:Infrastructure/Services/FileServer]`:trac:'
         )
         self.assertConvertedContent(
-            '`Overton <Infrastructure-Machines-Overton>`_\n',
+            '`Overton <Infrastructure-Machines-Overton>`_',
             '`[wiki:Infrastructure/Machines/Overton Overton]`:trac:'
         )
 
     def test_trac_ticket(self):
         """
-        Trac tickets get forwarded to the correct address.
+        Trac ticket references are converted to a hyperlink.
         This use case requires `config.py` with the following setting:
 
         TRAC_TICKET_PREFIX = 'https://trac.chevah.com/ticket/'
         """
         self.assertConvertedContent(
-            '`Trac #738 <https://trac.chevah.com/ticket/738>`_\n',
+            '`Trac #738 <https://trac.chevah.com/ticket/738>`_',
             ':trac:`#738`'
+        )
+
+    def test_heading(self):
+        """
+        Converts headings to RST, which have an equal-sign-underline.
+        Also handles the multiline case.
+
+        Headings in TracWiki have single equal signs around them.
+        """
+        self.assertConvertedContent(
+            'Heading\n'
+            '=======',
+
+            '= Heading ='
+        )
+        self.assertConvertedContent(
+            'Policy and Process\n'
+            '==================\n'
+            '\n'
+            'Some text',
+
+            '= Policy and Process =\n'
+            '\n'
+            'Some text'
+        )
+
+    def test_subheading(self):
+        """
+        Converts subheadings to RST, which have a dash-underline.
+        Also handle the multiline case.
+
+        Subheadings in TracWiki have double equal signs around them.
+        """
+        self.assertConvertedContent(
+            'Subheading\n'
+            '----------',
+
+            '== Subheading =='
+        )
+        self.assertConvertedContent(
+            'Subheading\n'
+            '----------\n'
+            '\n'
+            'Some text',
+
+            '== Subheading ==\n'
+            '\n'
+            'Some text'
+        )
+
+    def test_list_indented(self):
+        """
+        Un-indents list items that are indented by one space exactly.
+
+        This is to avoid RST interpreting lists indented by one space
+        as quotations; we want them as unquoted lists instead.
+        """
+        self.assertConvertedContent(
+            "* item 1\n"
+            "* item 2\n"
+            "* item 3",
+
+            " * item 1\n"
+            " * item 2\n"
+            " * item 3"
+        )
+
+    def test_list_after_paragraph(self):
+        """
+        Separates lists from paragraphs by one empty line.
+
+        In RST, when lists follow a paragraph without an empty line
+        inbetween, they fail to parse as lists.
+        """
+        self.assertConvertedContent(
+            "Paragraph\n\n"
+            "* item 1\n"
+            "* item 2\n"
+            "* item 3",
+
+            "Paragraph\n"
+            "* item 1\n"
+            "* item 2\n"
+            "* item 3"
+        )
+
+    def test_list_after_paragraph_idempotent(self):
+        """
+        Does not add another line when there is already a line between
+        a list and the paragraph before it.
+        """
+
+        self.assertConvertedContent(
+            "Paragraph\n\n"
+            "* item 1\n"
+            "* item 2\n"
+            "* item 3",
+
+            "Paragraph\n\n"
+            "* item 1\n"
+            "* item 2\n"
+            "* item 3"
+        )
+
+    def test_bold_is_not_list(self):
+        """
+        Italic text markup is preserved as in the TracWiki format.
+        """
+
+        self.assertConvertedContent(
+            "Paragraph\n"
+            "*italic text*",
+
+            "Paragraph\n"
+            "*italic text*",
         )
 
 

--- a/test/test_wiki_trac_rst_convert.py
+++ b/test/test_wiki_trac_rst_convert.py
@@ -3,7 +3,7 @@ import unittest
 from wiki_trac_rst_convert import convert_content
 
 
-class TracRstToVanillaRst(unittest.TestCase):
+class TracToVanillaRst(unittest.TestCase):
     """
     Test conversion of content from Trac-flavored reStructuredText to
     vanilla reStructuredText, that is supported by GitHub
@@ -105,6 +105,59 @@ class TracRstToVanillaRst(unittest.TestCase):
             '* Some content\n'
             '* :trac:`wiki:General/FreeSoftwareUsage`'
             ' List of free software used by Chevah Project.'
+        )
+
+    def test_tracwiki_general_link(self):
+        """
+        Process general links from TracWiki format to plain RST links
+        """
+        self.assertConvertedContent(
+            '`Buildbot <https://chevah.com/buildbot/>`_\n',
+            '[https://chevah.com/buildbot/ Buildbot]'
+        )
+
+    def test_tracwiki_wiki_link(self):
+        """
+        Process wiki links from TracWiki format to GitHub-compatible
+        RST wiki links.
+        There are various combinations of no-link-text, link-text-same-
+        as-article-name, and link-text-different-from-article-name.
+        """
+        self.assertConvertedContent(
+            '`Project management and administration <Administrative>`_\n',
+            '[wiki:Administrative Project management and administration]'
+        )
+        self.assertConvertedContent(
+            '`<Administrative>`_\n',
+            '[wiki:Administrative Administrative]'
+        )
+        self.assertConvertedContent(
+            '`<Administrative>`_\n',
+            '[wiki:"Administrative"]'
+        )
+        self.assertConvertedContent(
+            '`<Administrative-AllHandMeeting-Past>`_\n',
+            '[wiki:"Administrative/AllHandMeeting/Past"]'
+        )
+        self.assertConvertedContent(
+            '`<Infrastructure-Services-FileServer>`_\n',
+            '`[wiki:Infrastructure/Services/FileServer]`:trac:'
+        )
+        self.assertConvertedContent(
+            '`Overton <Infrastructure-Machines-Overton>`_\n',
+            '`[wiki:Infrastructure/Machines/Overton Overton]`:trac:'
+        )
+
+    def test_trac_ticket(self):
+        """
+        Trac tickets get forwarded to the correct address.
+        This use case requires `config.py` with the following setting:
+
+        TRAC_TICKET_PREFIX = 'https://trac.chevah.com/ticket/'
+        """
+        self.assertConvertedContent(
+            '`Trac #738 <https://trac.chevah.com/ticket/738>`_\n',
+            ':trac:`#738`'
         )
 
 

--- a/wiki_trac_rst_convert.py
+++ b/wiki_trac_rst_convert.py
@@ -3,6 +3,8 @@ import re
 import sys
 import os
 
+from config import TRAC_TICKET_PREFIX
+
 
 def main():
     """
@@ -44,36 +46,107 @@ def convert_content(text: str):
     for seq in to_remove:
         text = text.replace(seq, '')
     text = text.strip() + '\n'
-    text = _trac_rst_wiki_to_github_links(text)
+    text = _trac_to_github_wiki_links(text)
+    text = _tracwiki_to_rst_links(text)
+    text = _tracwiki_wiki_link_with_text_to_github_links(text)
+    text = _trac_ticket_links(text)
 
     return text
 
 
-def _trac_rst_wiki_to_github_links(text: str):
+def _trac_to_github_wiki_links(text: str):
     """
-    Takes RST content with Trac wiki link directives
-    and coverts the directives to inline GitHub wiki links.
+    Takes content with Trac wiki link directives and coverts
+    the directives to inline GitHub wiki links.
     """
 
-    link_matchers =[re.compile(r) for r in [
+    link_matchers = [re.compile(r) for r in [
+        # RST markup
         ':trac:`wiki:(.+?)`',
-        '`wiki:(.+?)`:trac:'
+        '`wiki:(.+?)`:trac:',
+
+        # TracWiki markup
+        '`\[wiki:"?([^ ]+?)"?]`:trac:',
+        '\[wiki:"?([^ ]+?)"?]',
     ]]
 
     for link_re in link_matchers:
         wiki_titles = re.findall(link_re, text)
         for title in wiki_titles:
-            text = re.sub(
-                link_re,
-                rf'`<{_wiki_url(title)}>`_',
-                text,
-                1
-            )
+            text = _sub(link_re, f'`<{_wiki_url(title)}>`_', text)
 
     return text
 
 
-def _wiki_url(title):
+def _tracwiki_to_rst_links(text: str):
+    """
+    Takes TracWiki markup and converts its links to RST links.
+    """
+
+    url = '[a-z]+://[^ ]+'
+    link_text = '[^]]+'
+    link_re = re.compile(f'\[({url}) ({link_text})]')
+
+    matches = re.findall(link_re, text)
+    for url, link_text in matches:
+        text = _sub(link_re, f'`{link_text} <{url}>`_', text)
+
+    return text
+
+
+def _tracwiki_wiki_link_with_text_to_github_links(text: str):
+    """
+    Takes TracWiki markup and converts its Wiki links which have
+    explicit link text into RST links.
+    If the link text is the same as the article name, generate a more
+    compact syntax.
+    """
+
+    title = '[^ ]+'
+    link_text = '[^]]+'
+
+    link_matchers = [re.compile(r) for r in [
+        f'`\[wiki:({title}) ({link_text})]`:trac:',
+        f'\[wiki:({title}) ({link_text})]',
+    ]]
+
+    for link_re in link_matchers:
+        matches = re.findall(link_re, text)
+        for title, link_text in matches:
+            if title == link_text:
+                text = _sub(link_re, f'`<{_wiki_url(title)}>`_', text)
+            else:
+                replacement = f'`{link_text} <{_wiki_url(title)}>`_'
+                text = _sub(link_re, replacement, text)
+
+    return text
+
+
+def _trac_ticket_links(text: str):
+    """
+    Replace Trac reference to ticket with actual link to the ticket
+    """
+
+    ticket_re = ':trac:`#([0-9]+)`'
+    matches = re.findall(ticket_re, text)
+    for ticket in matches:
+        text = _sub(
+            ticket_re,
+            f'`Trac #{ticket} <{TRAC_TICKET_PREFIX}{ticket}>`_',
+            text
+        )
+    return text
+
+
+def _sub(link_re: str, replacement: str, text: str):
+    """
+    Substitute one occurrence of `link_re` in `text` with `replacement`.
+    Return the resulting new text.
+    """
+    return re.sub(link_re, replacement, text, 1)
+
+
+def _wiki_url(title: str):
     """
     GitHub Wiki collapses directory structure.
 


### PR DESCRIPTION
Scope
=====

There are TracWiki markup links which need to be converted. Here are examples of files (taken from https://github.com/chevah/trac-to-github/issues/2#issuecomment-764700864_ ):

* TracWiki markup - https://trac.chevah.com/wiki/WikiStart?action=edit
* RST markup with Trac directives - https://trac.chevah.com/wiki/Development/Python?action=edit
* Mixed of RST with TracWiki macros (see bottom) - https://trac.chevah.com/wiki/Administrative?action=edit

At first, we can use this ticket to convert RST Trac links directives.

Later we should look at converting whole TracWiki pages.

Changes
=======

TracWiki links should now work. I have added a new match case to `_trac_rst_wiki_to_github_links`, as well as new methods that handle TracWiki link syntax (with or without link text different from the article).

Also Trac tickets should work. There were only 3 of them, but it was easy enough to automate. 

Only one malformed `:trac:` reference remains, which will be addressed manually.

TracWiki syntax: the script handles the following:
* title/heading syntax: heading (===) and subheading (---)
* lists: it unindents single-space-quoted lists, and adds an empty line before the first list element. The majority of files looks good; but nesting conversion is not proper.

What is not done
---------

About lists: I did not properly implement nesting. I started to, but it turned out to be too difficult for me, considering the diminishing returns. An exhaustive (as of 2021-01-27) list of failures:
* Architecture/Agent/General section "Remote file", under "steps"
* Development/GetToKnow section "Products documentation and download pages".
* Infrastructure/OutOfOrderMachines Mosna under "network cards"
* Infrastructure/Services/VPN under "Overton"
* Requirements/Vision, last two list items on page
* Support/General section "Initial Assessment"
* Support/CustomerDataBase/Template.rst and some files created from that template.

In addition, `{{{ }}}` code blocks need to be converted manually, by searching for `{{{` in a commit before stripping the `{{{#!rst }}}` armor.

How to try and test the changes
===============================

reviewers: @adiroiban 

First, copy the `config.py.sample` to `config.py`, because the Trac URL is specified as a config option.

Then, continue testing like PR #3:

> Run tests using `unittest` from the project directory:
> `python3.8 -m unittest`
> ## Checking output
> 
> I did not find an easy way to verify the GitHub link behavior. The only way to properly test is to run the conversion, then push and check the wiki.
> 
> There are some things you can still check locally:
> 
>   * run the script, and then look at the diff using gitk, with the "Ignore space change" checkbox checked.
> 
>   * check what `:trac:` markers are left
