### PR TITLE
Handle TracWiki PageOutline directive

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8
       - name: Prepare config
         run: |
           cp config.py.sample config.py

--- a/test/test_wiki_trac_rst_convert.py
+++ b/test/test_wiki_trac_rst_convert.py
@@ -14,14 +14,24 @@ class TracToGitHubRST(unittest.TestCase):
         Run the Trac RST `source` through the converter,
         and assert that the output equals `expected`.
 
-        Also expects the content to end with a newline. The newline is
-        added here for convenience and readability of test cases.
+        In addition, expects the content to end with a newline.
+        The newline is added here for convenience
+        and readability of test cases.
+
+        Also expects the content to start with a `contents` directive.
         """
-        self.assertEqual(expected + '\n', convert_content(source))
+        self.assertEqual(
+            '.. contents::\n'
+            '\n' +
+            expected + '\n',
+
+            convert_content(source)
+        )
 
     def test_empty(self):
         """
-        An empty string is appended a blank line.
+        An empty string is prepended a `contents` directive and
+        appended a blank line.
 
         A file not ending in a newline character is not POSIX compliant,
         and may result in complaints from programs, like `git diff`
@@ -35,6 +45,41 @@ class TracToGitHubRST(unittest.TestCase):
         A newline will not get appended another newline.
         """
         self.assertConvertedContent('', '\n')
+
+    def test_single_content_directive(self):
+        """
+        Ensure only one RST content directive, not multiple.
+        """
+
+        self.assertConvertedContent(
+            'Sample content',
+
+            '.. contents::\n'
+            '\n'
+            'Sample content'
+        )
+
+        self.assertConvertedContent(
+            'Sample content',
+
+            '..  contents::\n'
+            '\n'
+            'Sample content'
+        )
+
+    def test_remove_tracwiki_pageoutline(self):
+        """
+        Make sure no TracWiki [[PageOutline]] directives remain.
+        """
+
+        self.assertConvertedContent(
+            'Sample content',
+
+            '[[PageOutline]]\n'
+            '\n'
+            'Sample content'
+        )
+
 
     def test_removes_rst_wrapping(self):
         """

--- a/test/test_wiki_trac_rst_convert.py
+++ b/test/test_wiki_trac_rst_convert.py
@@ -106,6 +106,18 @@ class TracToGitHubRST(unittest.TestCase):
             )
         )
 
+    def test_remove_content_directive_with_extra_space(self):
+        """
+        Cleans a `contents` directive with too many spaces
+        between the `..` and the `contents::` part.
+        """
+        self.assertConvertedContent(
+            'Sample content',
+
+            '..  contents::\n'
+            '\n'
+            'Sample content'
+        )
 
     def test_remove_tracwiki_pageoutline(self):
         """
@@ -137,20 +149,6 @@ class TracToGitHubRST(unittest.TestCase):
                 '[[PageOutline]]\n'
             )
         )
-
-    def test_remove_content_directive_with_extra_space(self):
-        """
-        Cleans a `contents` directive with too many spaces
-        between the `..` and the `contents::` part.
-        """
-        self.assertConvertedContent(
-            'Sample content',
-
-            '..  contents::\n'
-            '\n'
-            'Sample content'
-        )
-
 
     def test_removes_rst_wrapping(self):
         """


### PR DESCRIPTION
Scope
=====

This is the easier part of ticket #5 . 
Ensure that the RST `.. contents::` directive exists on every page, and remove all TracWiki [[PageOutline]] directives.

Changes
=======

The changes were implemented by removing all `[[PageOutline]]` mentions, and then adding RST `.. contents::` to every page that is missing it.

Several places had the RST directive with an extra space; they are handled.

Also, address `pytest` warnings about escaping by using raw strings when needed for regexes.

Also, address a comment I missed about removing `pytest` args from the GitHub Action, now that there is a `setup.cfg`.

What is not done: The harder part of #5: replacing TracWiki `[[TitleIndex]]` directives with a list of RST links in a re-runnable and update-able way.

How to try and test the changes
===============================

reviewers: @adiroiban 

Check that all files have a mention of `.. contents::`::

    grep -rl . | egrep "rst$|rest$" | sort > all.txt
    grep -rl  "\.\. contents::"  | grep -v "\.git" | sort > contents.txt
    meld all.txt contents.txt

Meld (or your diff tool of choice) should show the same RST files inside.

Check that no files have more than one instance of `.. contents::`: the following command should not return anything:

     egrep -rc  "\.\.(\ )+contents::"  . | grep -v ":[01]$"

Also, I looked at the diff actual output of the script, and tried out changes in GitHub edit preview::

    python wiki_trac_rst_convert.py /path/to/server.wiki

