### PR TITLE
[Fix #20] Script to migrate FIXMEs

### DIFF
--- a/fixme_migrator.py
+++ b/fixme_migrator.py
@@ -1,0 +1,91 @@
+import os
+import re
+import sys
+
+FIXME_REGEX = re.compile(r'FIXME:(\d+):')
+
+
+def replace_match(match, ticket_mapping):
+    group = match.group(1)
+    try:
+        return f'FIXME:{ticket_mapping[group]}:'
+    except KeyError:
+        # print(f'Ticket ID not in this project: {group}')
+        # return f'FIXME:{group}:'
+        raise ValueError(f'Ticket ID not in this project: {group}')
+
+
+def migrate(ticket_mapping, text):
+    return FIXME_REGEX.sub(
+        lambda match: replace_match(match, ticket_mapping),
+        text
+        )
+
+
+def parse_tsv(project, tsv_text):
+    """
+    Parse content in TSV format with tickets created,
+    and selects only the ones for the given project name.
+    """
+    old_to_new = re.compile(
+        f'https://trac.chevah.com/ticket/(\\d+)\t'
+        f'https://github.com/chevah/{project}/issues/(\\d+)\n'
+        )
+
+    return {
+        match[0]: match[1]
+        for match in re.findall(old_to_new, tsv_text)
+        }
+
+
+def path_to_skip(fpath):
+    """
+    Returns true if a path should be skipped instead of migrated.
+    """
+    return any(substr in fpath for substr in [
+        '.git/',
+        '.pyc',
+        'node_modules',
+        'python2.7',
+        'nodeenv',
+        'build-server',
+        'release-notes',
+        ])
+
+
+def main():
+    """
+    Perform FIXME in-place migration on a given directory.
+    """
+    args = sys.argv[1:]
+    if len(args) != 1:
+        raise ValueError('There should be exactly one argument: '
+                         'the path to the directory to update.\n'
+                         f'Provided: {args}')
+
+    with open('tickets_created.tsv') as tickets_f:
+        tsv_text = tickets_f.read()
+        mapping = parse_tsv(project='server', tsv_text=tsv_text)
+
+        for root, dirs, fnames in os.walk(args[0]):
+            for fname in fnames:
+                fpath = os.path.join(root, fname)
+
+                if path_to_skip(fpath):
+                    continue
+
+                try:
+                    with open(fpath) as f:
+                        source_code = f.read()
+                        new_source = migrate(mapping, source_code)
+                    if source_code != new_source:
+                        with open(fpath, 'w') as f:
+                            print(f'Updating {fpath}...')
+                            f.write(new_source)
+                except UnicodeDecodeError:
+                    # Likely a binary file. Skip it.
+                    continue
+
+
+if __name__ == '__main__':
+    main()

--- a/fixme_migrator.py
+++ b/fixme_migrator.py
@@ -2,8 +2,9 @@ import os
 import re
 import sys
 
-FIXME_REGEX = re.compile(r'FIXME:(\d+):')
+# The GitHub name of the project we're working on.
 PROJECT_NAME = 'server'
+FIXME_REGEX = re.compile(r'FIXME:(\d+):')
 
 
 def should_skip_path(fpath):
@@ -28,9 +29,11 @@ def replace_match(match, ticket_mapping):
     try:
         return f'FIXME:{ticket_mapping[group]}:'
     except KeyError:
-        # print(f'Ticket ID not in this project: {group}')
-        # return f'FIXME:{group}:'
-        raise ValueError(f'Ticket ID not in this project: {group}')
+        if group in ticket_mapping.values():
+            print(f'Ticket ID may have been migrated: {group}')
+        else:
+            print(f'Ticket ID not in this project: {group}')
+        return f'FIXME:{group}:'
 
 
 def migrate(ticket_mapping, text):
@@ -83,7 +86,6 @@ def main():
                         new_source = migrate(mapping, source_code)
                     if source_code != new_source:
                         with open(fpath, 'w') as f:
-                            print(f'Updating {fpath}...')
                             f.write(new_source)
                 except UnicodeDecodeError:
                     # Likely a binary file. Skip it.

--- a/test/test_migrate_fixmes.py
+++ b/test/test_migrate_fixmes.py
@@ -1,0 +1,95 @@
+import unittest
+from fixme_migrator import migrate, parse_tsv
+
+
+class TestMigration(unittest.TestCase):
+    def test_migrate(self):
+        """
+        Replace old ticket IDs in a text with new ones from a mapping.
+        Returns the new text.
+        """
+
+        old_to_new = {'1234': '1235'}
+        text = """
+            # FIXME:1234:
+            Some other text here.
+            """
+
+        self.assertEqual(
+            migrate(old_to_new, text),
+            """
+            # FIXME:1235:
+            Some other text here.
+            """)
+
+    def test_migrate_overlap(self):
+        """
+        When a new ticket has the same ID as a different old one,
+        the system migrates both correctly.
+        """
+
+        old_to_new = {'12': '34', '34': '12'}
+        text = """
+            # FIXME:12:
+            # FIXME:34:
+            """
+
+        self.assertEqual(
+            migrate(old_to_new, text),
+            """
+            # FIXME:34:
+            # FIXME:12:
+            """
+            )
+
+    def test_fixme_unknown(self):
+        """
+        Throws an error on an unknown FIXME.
+        """
+        old_to_new = {'1234': '1235'}
+        text = """
+            # FIXME:1235:
+            Some other text here.
+            """
+
+        with self.assertRaises(ValueError) as error:
+            migrate(old_to_new, text)
+        self.assertEqual(
+            str(error.exception),
+            'Ticket ID not in this project: 1235'
+            )
+
+
+class TestProjectFilter(unittest.TestCase):
+    def test_tsv_parse(self):
+        """
+        Parses a TSV into a dictionary of old ID -> new ID.
+        """
+        tsv_text = """
+https://trac.chevah.com/ticket/2166	https://github.com/chevah/server/issues/2166
+https://trac.chevah.com/ticket/1891	https://github.com/chevah/server/issues/5459
+"""
+        self.assertEqual(
+            parse_tsv(project='server', tsv_text=tsv_text),
+            {'2166': '2166', '1891': '5459'}
+            )
+
+    def test_project_filter(self):
+        """
+        Out of a TSV with tickets migrated to various projects,
+        it only selects the current one for migration.
+        """
+        tsv_text = """
+https://trac.chevah.com/ticket/2166	https://github.com/chevah/server/issues/2166
+https://trac.chevah.com/ticket/10	https://github.com/chevah/sftpplus.com/issues/373
+https://trac.chevah.com/ticket/1891	https://github.com/chevah/server/issues/5459
+https://trac.chevah.com/ticket/5052	https://github.com/chevah/sftpplus.com/issues/387
+"""
+        self.assertEqual(
+            parse_tsv(project='server', tsv_text=tsv_text),
+            {'2166': '2166', '1891': '5459'}
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_migrate_fixmes.py
+++ b/test/test_migrate_fixmes.py
@@ -44,7 +44,7 @@ class TestMigration(unittest.TestCase):
 
     def test_fixme_unknown(self):
         """
-        Throws an error on an unknown FIXME.
+        A FIXME for a ticket not in the current project is not changed.
         """
         old_to_new = {'1234': '1235'}
         text = """
@@ -52,12 +52,7 @@ class TestMigration(unittest.TestCase):
             Some other text here.
             """
 
-        with self.assertRaises(ValueError) as error:
-            migrate(old_to_new, text)
-        self.assertEqual(
-            str(error.exception),
-            'Ticket ID not in this project: 1235'
-            )
+        self.assertEqual(migrate(old_to_new, text), text)
 
 
 class TestProjectFilter(unittest.TestCase):


### PR DESCRIPTION
Fix #20 

Added script to migrate a project, and tests.

For FIXMEs pertaining to a different project than the one configured, it prints a message which needs manual follow-up (such as creating or moving a ticket to the current project).

reviewers: @adiroiban 